### PR TITLE
Add better listener methods on EntityContainer and AttributeContainer, plus associated tests

### DIFF
--- a/src/main/java/jalse/attributes/AttributeContainer.java
+++ b/src/main/java/jalse/attributes/AttributeContainer.java
@@ -277,6 +277,58 @@ public interface AttributeContainer {
     }
 
     /**
+     * Checks whether the container contains a particular listener for a given attribute type.
+     *
+     * @param namedType
+     *            Named attribute type.
+     * @param listener
+     *            Listener to check presence of.
+     * @return Whether the attribute has any listeners.
+     */
+    default <T> boolean hasAttributeListener(final NamedAttributeType<T> namedType, final AttributeListener<T> listener) {
+	return hasAttributeListener(namedType.getName(), namedType.getType(), listener);
+    }
+
+    /**
+     * Checks whether the container contains a particular listener for a given attribute type.
+     *
+     * @param name
+     *            Attribute type name.
+     * @param type
+     *            Attribute type.
+     * @param listener
+     *            Listener to check presence of.
+     * @return Whether the attribute has any listeners.
+     */
+    default <T> boolean hasAttributeListener(final String name, final AttributeType<T> type, final AttributeListener<T> listener) {
+	return getAttributeListeners(name, type).contains(listener);
+    }
+
+    /**
+     * Checks whether the container contains any listeners for a given attribute type.
+     *
+     * @param namedType
+     *            Named attribute type.
+     * @return Whether the attribute has any listeners.
+     */
+    default <T> boolean hasAttributeListeners(final NamedAttributeType<T> namedType) {
+	return hasAttributeListeners(namedType.getName(), namedType.getType());
+    }
+
+    /**
+     * Checks whether the container contains any listeners for a given attribute type.
+     *
+     * @param name
+     *            Attribute type name.
+     * @param type
+     *            Attribute type.
+     * @return Whether the attribute has any listeners.
+     */
+    default <T> boolean hasAttributeListeners(final String name, final AttributeType<T> type) {
+	return !getAttributeListeners(name, type).isEmpty();
+    }
+
+    /**
      * Removes the attribute matching the supplied type.
      *
      * @param namedType

--- a/src/main/java/jalse/entities/EntityContainer.java
+++ b/src/main/java/jalse/entities/EntityContainer.java
@@ -182,6 +182,17 @@ public interface EntityContainer {
     }
 
     /**
+     * Checks whether the container contains a particular listener.
+     *
+     * @param entityListener
+     *            The EntityListener to check for.
+     * @return Whether the container contains the given EntityListener.
+     */
+    default boolean hasEntityListener(final EntityListener entityListener) {
+	return getEntityListeners().contains(entityListener);
+    }
+
+    /**
      * Kills all entities.
      */
     void killEntities();

--- a/src/test/java/attributes/AttributeContainerTest.java
+++ b/src/test/java/attributes/AttributeContainerTest.java
@@ -1,0 +1,141 @@
+package attributes;
+
+import jalse.attributes.Attributes;
+import jalse.attributes.DefaultAttributeContainer;
+import jalse.attributes.NamedAttributeType;
+import jalse.listeners.AttributeEvent;
+import jalse.listeners.AttributeListener;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AttributeContainerTest {
+
+    private class TestAttributeListener implements AttributeListener<Integer> {
+
+	public boolean changed = false;
+
+	@Override
+	public void attributeAdded(final AttributeEvent<Integer> event) {}
+
+	@Override
+	public void attributeChanged(final AttributeEvent<Integer> event) {
+	    changed = true;
+	}
+
+	@Override
+	public void attributeRemoved(final AttributeEvent<Integer> event) {}
+    }
+
+    DefaultAttributeContainer container = null;
+
+    @Test
+    public void addFromContainerTest() {
+	final NamedAttributeType<Integer> namedAttributeType = new NamedAttributeType<Integer>("test",
+		Attributes.INTEGER_TYPE);
+	final TestAttributeListener attributeListener = new TestAttributeListener();
+	container = new DefaultAttributeContainer();
+
+	container.setAttribute(namedAttributeType, 10);
+	container.addAttributeListener(namedAttributeType, attributeListener);
+
+	DefaultAttributeContainer otherContainer = new DefaultAttributeContainer();
+	otherContainer.addAllAttributes(container);
+	Assert.assertTrue(otherContainer.getAttributes().contains(10));
+	otherContainer.addAllAttributeListeners(container);
+	Assert.assertTrue(otherContainer.getAttributeListeners(namedAttributeType).contains(attributeListener));
+
+	otherContainer = new DefaultAttributeContainer();
+	otherContainer.addAll(container);
+	Assert.assertTrue(otherContainer.getAttributes().contains(10));
+	Assert.assertTrue(otherContainer.getAttributeListeners(namedAttributeType).contains(attributeListener));
+    }
+
+    @After
+    public void after() {
+	container = null;
+    }
+
+    @Test
+    public void attributeListenerTest() {
+	final NamedAttributeType<Integer> namedAttributeType = new NamedAttributeType<Integer>("test",
+		Attributes.INTEGER_TYPE);
+	final TestAttributeListener attributeListener = new TestAttributeListener();
+	container = new DefaultAttributeContainer();
+
+	container.addAttributeListener(namedAttributeType, attributeListener);
+	Assert.assertTrue(container.hasAttributeListeners(namedAttributeType));
+	Assert.assertTrue(container.hasAttributeListeners(namedAttributeType.getName(), namedAttributeType.getType()));
+	Assert.assertTrue(container.hasAttributeListener(namedAttributeType, attributeListener));
+	Assert.assertTrue(container.hasAttributeListener(namedAttributeType.getName(), namedAttributeType.getType(),
+		attributeListener));
+
+	Assert.assertEquals(1, container.getAttributeListeners(namedAttributeType).size());
+	Assert.assertTrue(container.getAttributeListeners(namedAttributeType).contains(attributeListener));
+
+	container.setAttribute(namedAttributeType, 10);
+	Assert.assertFalse(attributeListener.changed);
+	container.fireAttributeChanged(namedAttributeType);
+	Assert.assertTrue(attributeListener.changed);
+
+	container.removeAttributeListener(namedAttributeType, attributeListener);
+	Assert.assertFalse(container.hasAttributeListeners(namedAttributeType));
+	Assert.assertFalse(container.hasAttributeListeners(namedAttributeType.getName(), namedAttributeType.getType()));
+	Assert.assertFalse(container.hasAttributeListener(namedAttributeType, attributeListener));
+	Assert.assertFalse(container.hasAttributeListener(namedAttributeType.getName(), namedAttributeType.getType(),
+		attributeListener));
+
+	container.addAttributeListener(namedAttributeType, attributeListener);
+	container.removeAttributeListeners(namedAttributeType);
+	Assert.assertFalse(container.hasAttributeListeners(namedAttributeType));
+    }
+
+    @Test
+    public void attributeTest() {
+	final NamedAttributeType<Integer> namedAttributeType = new NamedAttributeType<Integer>("test",
+		Attributes.INTEGER_TYPE);
+	container = new DefaultAttributeContainer();
+
+	container.setAttribute(namedAttributeType, 10);
+	Assert.assertTrue(container.hasAttributes());
+	Assert.assertTrue(container.hasAttribute(namedAttributeType));
+	Assert.assertTrue(container.hasAttribute(namedAttributeType.getName(), namedAttributeType.getType()));
+	Assert.assertEquals(10, (int) container.getAttribute(namedAttributeType));
+
+	final HashSet<?> attributes = (HashSet<?>) container.getAttributes();
+	Assert.assertEquals(1, attributes.size());
+	Assert.assertTrue(attributes.contains(10));
+
+	container.removeAttribute(namedAttributeType);
+	Assert.assertFalse(container.hasAttributes());
+	Assert.assertFalse(container.hasAttribute(namedAttributeType));
+	Assert.assertFalse(container.hasAttribute(namedAttributeType.getName(), namedAttributeType.getType()));
+    }
+
+    @Test
+    public void optAttributeTest() {
+	final NamedAttributeType<Integer> namedAttributeType = new NamedAttributeType<Integer>("test",
+		Attributes.INTEGER_TYPE);
+	container = new DefaultAttributeContainer();
+
+	Optional<Integer> set = container.setOptAttribute(namedAttributeType, 10);
+	Assert.assertFalse(set.isPresent());
+	set = container.setOptAttribute(namedAttributeType, 20);
+	Assert.assertEquals(10, (int) set.get());
+
+	Optional<Integer> get = container.getOptAttribute(namedAttributeType);
+	Assert.assertEquals(20, (int) get.get());
+
+	Optional<Integer> removed = container.removeOptAttribute(namedAttributeType);
+	Assert.assertEquals(20, (int) removed.get());
+	removed = container.removeOptAttribute(namedAttributeType);
+	Assert.assertFalse(removed.isPresent());
+
+	get = container.getOptAttribute(namedAttributeType);
+	Assert.assertFalse(get.isPresent());
+    }
+}

--- a/src/test/java/jalse/entities/EntityContainerTest.java
+++ b/src/test/java/jalse/entities/EntityContainerTest.java
@@ -1,0 +1,136 @@
+package jalse.entities;
+
+import static jalse.entities.Entities.asType;
+import jalse.listeners.EntityEvent;
+import jalse.listeners.EntityListener;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EntityContainerTest {
+
+    private interface TestEntity extends Entity {}
+
+    private class TestEntityListener implements EntityListener {
+
+	@Override
+	public void entityCreated(final EntityEvent event) {}
+
+	@Override
+	public void entityKilled(final EntityEvent event) {}
+
+	@Override
+	public void entityReceived(final EntityEvent event) {}
+
+	@Override
+	public void entityTransferred(final EntityEvent event) {}
+    }
+
+    EntityContainer container = null;
+
+    @Test
+    public void addEntityTest() {
+	container = new DefaultEntityContainer();
+
+	Assert.assertFalse(container.hasEntities());
+	container.newEntity();
+	container.newEntity(new UUID(0, 0));
+	Assert.assertEquals(2, container.getEntityCount());
+	Assert.assertTrue(container.hasEntities());
+	Assert.assertNotNull(container.getEntities());
+	Assert.assertTrue(container.hasEntity(new UUID(0, 0)));
+	Assert.assertFalse(container.hasEntity(new UUID(0, 100)));
+
+	Optional<Entity> optEntity = container.getOptEntity(new UUID(0, 100));
+	Assert.assertFalse(optEntity.isPresent());
+	optEntity = container.getOptEntity(new UUID(0, 0));
+	Assert.assertTrue(optEntity.isPresent());
+    }
+
+    @After
+    public void after() {
+	container = null;
+    }
+
+    @Test
+    public void entityClassTest() {
+	container = new DefaultEntityContainer();
+
+	container.newEntity();
+	container.newEntity(new UUID(0, 0));
+	container.newEntity(TestEntity.class);
+	container.newEntity(new UUID(0, 1), TestEntity.class);
+
+	final HashSet<DefaultEntity> entities = (HashSet<DefaultEntity>) container
+		.getEntitiesOfType(DefaultEntity.class);
+	for (final Entity entity : entities) {
+	    Assert.assertEquals(DefaultEntity.class, entity.getClass());
+	}
+	final Stream<DefaultEntity> entityStream = container.streamEntitiesOfType(DefaultEntity.class);
+	entityStream.forEach(e -> Assert.assertEquals(DefaultEntity.class, e.getClass()));
+
+	final Class<? extends TestEntity> type = asType(container.getEntity(new UUID(0, 0)), TestEntity.class)
+		.getClass();
+	Assert.assertEquals(type, container.getEntityAsType(new UUID(0, 0), TestEntity.class).getClass());
+	Assert.assertNull(container.getEntityAsType(new UUID(0, 100), TestEntity.class));
+
+	final HashSet<TestEntity> testEntities = (HashSet<TestEntity>) container.getEntitiesAsType(TestEntity.class);
+	for (final Entity entity : testEntities) {
+	    Assert.assertEquals(type, entity.getClass());
+	}
+	final Stream<TestEntity> testEntityStream = container.streamEntitiesAsType(TestEntity.class);
+	testEntityStream.forEach(e -> Assert.assertEquals(type, e.getClass()));
+
+	final Optional<TestEntity> optEntity = container.getOptEntityAsType(new UUID(0, 0), TestEntity.class);
+	Assert.assertTrue(optEntity.isPresent());
+	Assert.assertEquals(type, optEntity.get().getClass());
+    }
+
+    @Test
+    public void entityListenerTest() {
+	container = new DefaultEntityContainer();
+
+	final UUID id = new UUID(0, 0);
+	container.newEntity(id);
+
+	final TestEntityListener entityListener = new TestEntityListener();
+	Assert.assertFalse(container.hasEntityListener(entityListener));
+
+	container.addEntityListener(entityListener);
+	Assert.assertTrue(container.hasEntityListener(entityListener));
+    }
+
+    @Test
+    public void transferTest() {
+	container = new DefaultEntityContainer();
+
+	final UUID id = new UUID(0, 0);
+	container.newEntity(id);
+
+	final DefaultEntityContainer otherContainer = new DefaultEntityContainer();
+	Assert.assertTrue(container.transferAllEntities(otherContainer).isEmpty());
+	Assert.assertFalse(container.hasEntities());
+
+	final HashSet<UUID> idSet = new HashSet<UUID>();
+	idSet.add(new UUID(0, 1));
+	idSet.add(new UUID(0, 2));
+	container.newEntity(new UUID(0, 1));
+	container.newEntity(new UUID(0, 2));
+	container.transferEntities(idSet, otherContainer).isEmpty();
+	Assert.assertFalse(container.hasEntities());
+
+	otherContainer.transferEntities(p -> !p.getID().equals(new UUID(0, 0)), container);
+	System.out.println(otherContainer.getEntityIDs());
+	System.out.println(container.getEntityIDs());
+	Assert.assertTrue(otherContainer.getEntityIDs().contains(new UUID(0, 0)));
+	Assert.assertFalse(otherContainer.getEntityIDs().contains(new UUID(0, 1)));
+	Assert.assertFalse(container.getEntityIDs().contains(new UUID(0, 0)));
+	Assert.assertTrue(container.getEntityIDs().contains(new UUID(0, 1)));
+    }
+}


### PR DESCRIPTION
Resolves #45.

I used `hasEntityListener` and `hasAttributeListener(s)`, respectively, instead of `hasListener(s)`, to be more in keeping with other methods.

Also added tests for `EntityContainer` and `AttributeContainer`, which bumps the test coverage to around 49% (#82).
