### PR TITLE
Fixed issue #178

### DIFF
--- a/src/main/java/jalse/entities/EntityContainer.java
+++ b/src/main/java/jalse/entities/EntityContainer.java
@@ -326,12 +326,18 @@ public interface EntityContainer {
     }
 
     /**
-     * explain why we made it a Entity, rather than T
-     * justify that if it has multiple types in the beginning, it's arbitrary which one
-     * to return etc etc
+     * Creates a new entity with a specified ID and a Collection of types that it should 
+     * be marked as.
+     * 
      * @param id
+     * 			Entity ID
      * @param types
+     * 			Collection of Entity types. Can be empty
      * @return
+     * 			Returns Entity instead of T to account for an 
+     * 			Empty Collection of types. If there are multiple 
+     * 			types in the beginning, it's arbitrary which one 
+     * 			to return
      */
     default Entity newEntity(final UUID id, final Collection<Class<? extends Entity>> types) {
 	    Iterator<Class<? extends Entity>> iter = types.iterator();

--- a/src/main/java/jalse/entities/EntityContainer.java
+++ b/src/main/java/jalse/entities/EntityContainer.java
@@ -3,7 +3,9 @@ package jalse.entities;
 import static jalse.attributes.Attributes.EMPTY_ATTRIBUTECONTAINER;
 import static jalse.entities.Entities.asType;
 
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -323,6 +325,23 @@ public interface EntityContainer {
 	return newEntity(id, type, EMPTY_ATTRIBUTECONTAINER);
     }
 
+    /**
+     * explain why we made it a Entity, rather than T
+     * justify that if it has multiple types in the beginning, it's arbitrary which one
+     * to return etc etc
+     * @param id
+     * @param types
+     * @return
+     */
+    default Entity newEntity(final UUID id, final Collection<Class<? extends Entity>> types) {
+	    Iterator<Class<? extends Entity>> iter = types.iterator();
+	    Entity myEntity = newEntity(id, EMPTY_ATTRIBUTECONTAINER);
+	    while(iter.hasNext()) {
+	      myEntity.markAsType(iter.next());
+	    }
+	    return myEntity;
+	}
+    
     /**
      * Creates new entity with the specified ID. This entity is marked as the specified entity type
      * and then wrapped to it.

--- a/src/test/java/jalse/entities/DefaultEntityContainerTest.java
+++ b/src/test/java/jalse/entities/DefaultEntityContainerTest.java
@@ -1,5 +1,7 @@
 package jalse.entities;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -320,5 +322,20 @@ public class DefaultEntityContainerTest {
 	// Try transferring an entity that the container no longer contains.
 	Assert.assertFalse(container.transferEntity(id, otherContainer));
 
+    }
+    
+    private interface T1 extends Entity {};
+
+    @Test
+    public void multiTypeEntityTest() {
+    	final UUID id = new UUID(0, 0);
+    	EntityContainer container = new DefaultEntityContainer();
+    	Collection<Class<? extends Entity>> types = new ArrayList<Class<? extends Entity>>();
+    	types.add(TestEntity.class);
+    	types.add(T1.class);
+    	Entity e = container.newEntity(id, types);
+    	
+    	Assert.assertTrue(e.isMarkedAsType(T1.class));
+    	Assert.assertTrue(e.isMarkedAsType(TestEntity.class));
     }
 }


### PR DESCRIPTION
Fixed Issue #178: Consider being able to initialize an entity with multiple types

Added a new implementation of the newEntity method in EntityContainer.java. This implementation takes a Collection of types as a parameter and returns an Entity with all input types marked.

This change was tested using the gradle testing framework. We added the test to DefaultEntityContainerTest.java where we create a new Entity with a Collection of types using the new method declaration of newEntity.
