### PR TITLE
Code quality fix - Assignments should not be made from within sub-expressions.

### DIFF
--- a/src/main/java/jalse/actions/ForkJoinActionEngine.java
+++ b/src/main/java/jalse/actions/ForkJoinActionEngine.java
@@ -167,8 +167,8 @@ public class ForkJoinActionEngine extends AbstractActionEngine {
     protected boolean addWork(final ForkJoinContext<?> context) {
 	requireNotStopped(this);
 
-	final boolean result;
-	if (result = workQueue.addWaitingWork(context)) {
+	final boolean result = workQueue.addWaitingWork(context);
+	if (result) {
 	    addWorkerIfNeeded();
 	}
 

--- a/src/main/java/jalse/actions/ManualWorkQueue.java
+++ b/src/main/java/jalse/actions/ManualWorkQueue.java
@@ -50,8 +50,8 @@ public class ManualWorkQueue<T extends AbstractManualActionContext<?>> {
     public boolean addWaitingWork(final T context) {
 	write.lock();
 	try {
-	    boolean result;
-	    if (result = !waitingWork.contains(context)) {
+	    boolean result = !waitingWork.contains(context);
+	    if (result) {
 		waitingWork.add(context);
 		workChanged.signalAll(); // Wake up!
 	    }
@@ -177,8 +177,8 @@ public class ManualWorkQueue<T extends AbstractManualActionContext<?>> {
     public boolean removeWaitingWork(final T context) {
 	write.lock();
 	try {
-	    boolean result;
-	    if (result = waitingWork.remove(context)) {
+	    boolean result = waitingWork.remove(context);
+	    if (result) {
 		workChanged.signalAll();
 	    }
 	    return result;

--- a/src/main/java/jalse/attributes/DefaultAttributeContainer.java
+++ b/src/main/java/jalse/attributes/DefaultAttributeContainer.java
@@ -64,7 +64,8 @@ public class DefaultAttributeContainer implements AttributeContainer {
 
 	    Set<AttributeListener<?>> lst = builderListeners.get(namedType);
 	    if (lst == null) {
-		builderAttributes.put(namedType, lst = new HashSet<>());
+	        lst = new HashSet<>();
+	        builderAttributes.put(namedType, lst);
 	    }
 
 	    lst.add(listener);
@@ -206,7 +207,8 @@ public class DefaultAttributeContainer implements AttributeContainer {
 
 	    if (lst == null) {
 		// No existing listeners
-		listeners.put(namedType, lst = new ListenerSet<>(AttributeListener.class));
+	        lst = new ListenerSet<>(AttributeListener.class);
+	        listeners.put(namedType, lst);
 	    }
 
 	    return lst.add(listener);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:AssignmentInSubExpressionCheck - Assignments should not be made from within sub-expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:AssignmentInSubExpressionCheck

Please let me know if you have any questions.

Faisal Hameed
