### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/jalse/misc/AbstractIdentifiable.java
+++ b/src/main/java/jalse/misc/AbstractIdentifiable.java
@@ -9,7 +9,7 @@ import java.util.UUID;
  *
  * @author Elliot Ford
  *
- * @see Identifiable#equals(Identifiable, Object)
+ * @see Identifiable#areEqual(Identifiable, Object)
  * @see Identifiable#hashCode(Identifiable)
  * @see Identifiable#toString(Identifiable)
  *
@@ -42,7 +42,7 @@ public abstract class AbstractIdentifiable implements Identifiable {
 
     @Override
     public boolean equals(final Object obj) {
-	return Identifiable.equals(this, obj);
+	return Identifiable.areEqual(this, obj);
     }
 
     @Override

--- a/src/main/java/jalse/misc/Identifiable.java
+++ b/src/main/java/jalse/misc/Identifiable.java
@@ -22,7 +22,7 @@ public interface Identifiable {
      *            Second object.
      * @return Whether the unique identifiers are equal.
      */
-    static boolean equals(final Identifiable a, final Object b) {
+    static boolean areEqual(final Identifiable a, final Object b) {
 	return a == b
 		|| a != null && b instanceof Identifiable && Objects.equals(a.getID(), ((Identifiable) b).getID());
     }
@@ -56,10 +56,10 @@ public interface Identifiable {
      *            Identifiable to check for.
      * @return Predicate of {@code true} if the identifiable is equal or {@code false} if it is not.
      *
-     * @see Identifiable#equals(Identifiable, Object)
+     * @see Identifiable#areEqual(Identifiable, Object)
      */
     static Predicate<Identifiable> is(final Identifiable obj) {
-	return i -> equals(obj, i);
+	return i -> areEqual(obj, i);
     }
 
     /**

--- a/src/test/java/jalse/entities/EntitiesTest.java
+++ b/src/test/java/jalse/entities/EntitiesTest.java
@@ -10,6 +10,8 @@ import jalse.attributes.Attributes;
 import jalse.attributes.NamedAttributeType;
 
 public class EntitiesTest {
+    
+    private EntitiesTest() {}
 
     public static class RecursiveAttributeListenerTest {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1201 - Methods named "equals" should override Object.equals(Object).
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1201
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
